### PR TITLE
Monetization: 14-day trial, variant paywalls, multi-group calc, exit-intent, annual upsell + build fix

### DIFF
--- a/__tests__/pension-calculations.test.ts
+++ b/__tests__/pension-calculations.test.ts
@@ -4,6 +4,7 @@ import {
   calculateAverageHighestSalary,
   calculateRetirementEligibility,
   calculateCOLAProjection,
+  calculateMultiGroupPension,
   type PensionCalculationResult,
   type EmployeeGroup
 } from '@/lib/pension-calculations'
@@ -268,6 +269,137 @@ describe('Pension Calculations', () => {
       expect(result.averageSalary).toBe(0)
       expect(result.annualPension).toBe(0)
       expect(result.monthlyPension).toBe(0)
+    })
+  })
+
+  describe('calculateMultiGroupPension', () => {
+    it('matches the single-segment path for a 1-segment career', () => {
+      const result = calculateMultiGroupPension(
+        [{ group: 'GROUP_2', yearsOfService: 30 }],
+        55,
+        75000,
+        'A',
+        'before_2012',
+      )
+      expect(result.eligible).toBe(true)
+      expect(result.totalYearsOfService).toBe(30)
+      expect(result.retirementGroup).toBe('GROUP_2')
+      expect(result.basePercentage).toBeCloseTo(0.6, 5)
+      expect(result.baseAnnualPension).toBeCloseTo(75000 * 0.6, 2)
+      expect(result.annualPension).toBeCloseTo(75000 * 0.6, 2)
+      expect(result.cappedBase).toBe(false)
+    })
+
+    it('correctly prorates 5 yrs Group 4 + 30 yrs Group 2 at age 55 (the canonical user scenario)', () => {
+      // Segment 1: 5 yrs * 2.5% (Group 4 at age 55) = 12.5%
+      // Segment 2: 30 yrs * 2.0% (Group 2 at age 55) = 60.0%
+      // Combined: 72.5% (under 80% cap)
+      const averageSalary = 80000
+      const result = calculateMultiGroupPension(
+        [
+          { group: 'GROUP_4', yearsOfService: 5 },
+          { group: 'GROUP_2', yearsOfService: 30 },
+        ],
+        55,
+        averageSalary,
+        'A',
+        'before_2012',
+      )
+      expect(result.eligible).toBe(true)
+      expect(result.totalYearsOfService).toBe(35)
+      expect(result.retirementGroup).toBe('GROUP_2') // retirement group is the last segment
+      expect(result.basePercentage).toBeCloseTo(0.725, 5)
+      expect(result.baseAnnualPension).toBeCloseTo(averageSalary * 0.725, 2)
+      expect(result.cappedBase).toBe(false)
+      expect(result.segmentBreakdown).toHaveLength(2)
+      expect(result.segmentBreakdown[0].benefitFactor).toBeCloseTo(0.025, 5)
+      expect(result.segmentBreakdown[1].benefitFactor).toBeCloseTo(0.02, 5)
+      expect(result.segmentBreakdown[0].segmentPercentage).toBeCloseTo(0.125, 5)
+      expect(result.segmentBreakdown[1].segmentPercentage).toBeCloseTo(0.6, 5)
+    })
+
+    it('applies the 80% cap to the combined benefit', () => {
+      // 30 yrs Group 4 at 55 (2.5%) + 20 yrs Group 2 at 55 (2.0%) = 75% + 40% = 115% -> capped to 80%
+      const averageSalary = 80000
+      const result = calculateMultiGroupPension(
+        [
+          { group: 'GROUP_4', yearsOfService: 30 },
+          { group: 'GROUP_2', yearsOfService: 20 },
+        ],
+        55,
+        averageSalary,
+        'A',
+        'before_2012',
+      )
+      expect(result.eligible).toBe(true)
+      expect(result.cappedBase).toBe(true)
+      expect(result.basePercentage).toBeCloseTo(0.8, 5)
+      expect(result.baseAnnualPension).toBeCloseTo(averageSalary * 0.8, 2)
+    })
+
+    it('applies Option B 1% reduction to the combined base', () => {
+      const averageSalary = 80000
+      const resultA = calculateMultiGroupPension(
+        [
+          { group: 'GROUP_4', yearsOfService: 5 },
+          { group: 'GROUP_2', yearsOfService: 30 },
+        ],
+        55,
+        averageSalary,
+        'A',
+        'before_2012',
+      )
+      const resultB = calculateMultiGroupPension(
+        [
+          { group: 'GROUP_4', yearsOfService: 5 },
+          { group: 'GROUP_2', yearsOfService: 30 },
+        ],
+        55,
+        averageSalary,
+        'B',
+        'before_2012',
+      )
+      expect(resultB.annualPension).toBeCloseTo(resultA.annualPension * 0.99, 2)
+    })
+
+    it('reports ineligibility when combined service does not meet minimums', () => {
+      // Group 1 post-2012 requires age 60 and 10+ YOS. 5 + 3 = 8 < 10 fails.
+      const result = calculateMultiGroupPension(
+        [
+          { group: 'GROUP_2', yearsOfService: 5 },
+          { group: 'GROUP_1', yearsOfService: 3 },
+        ],
+        60,
+        75000,
+        'A',
+        'after_2012',
+      )
+      expect(result.eligible).toBe(false)
+      expect(result.annualPension).toBe(0)
+    })
+
+    it('uses the retirement group (last segment) for option C reduction factor', () => {
+      // GROUP_1 uses different Option C factors than GROUP_2/3/4.
+      // A career ending in Group 1 at age 60 with a 58 beneficiary should use
+      // GROUP_1_OPTION_C_FACTORS ("60-58" = 0.9065).
+      const result = calculateMultiGroupPension(
+        [
+          { group: 'GROUP_2', yearsOfService: 10 },
+          { group: 'GROUP_1', yearsOfService: 20 },
+        ],
+        60,
+        80000,
+        'C',
+        'before_2012',
+        '58',
+      )
+      expect(result.eligible).toBe(true)
+      expect(result.retirementGroup).toBe('GROUP_1')
+      // Base combined percent at age 60: 10*0.025 + 20*0.02 = 0.25 + 0.4 = 0.65
+      // Base annual = 52000 ; Option C factor (60-58 in GROUP_1) = 0.9065
+      expect(result.baseAnnualPension).toBeCloseTo(52000, 2)
+      expect(result.annualPension).toBeCloseTo(52000 * 0.9065, 0)
+      expect(result.survivorAnnualPension).toBeCloseTo(result.annualPension * (2 / 3), 0)
     })
   })
 })

--- a/app/api/cron/auto-blog/route.ts
+++ b/app/api/cron/auto-blog/route.ts
@@ -1,4 +1,5 @@
 export const maxDuration = 60
+export const dynamic = 'force-dynamic'
 
 /**
  * Weekly Auto-Blog Generator
@@ -11,13 +12,21 @@ export const maxDuration = 60
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
 
-// Supabase client for direct database access
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
-)
+// Lazy Supabase client — do NOT instantiate at module load (breaks `next build`
+// "Collecting page data" when env vars aren't injected).
+let _supabase: SupabaseClient | null = null
+function getSupabase(): SupabaseClient {
+  if (_supabase) return _supabase
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!url || !key) {
+    throw new Error('Supabase env vars (NEXT_PUBLIC_SUPABASE_URL + service/anon key) are not configured')
+  }
+  _supabase = createClient(url, key)
+  return _supabase
+}
 
 // ─── Topic Pool ────────────────────────────────────────────────────────────────
 // Covers retirement trends, planning tips, and policy/legislative updates
@@ -86,7 +95,7 @@ export async function GET(request: NextRequest) {
     const slug = generateSlug(content.title)
     const now = new Date().toISOString()
 
-    const { data, error } = await supabase.from('blog_posts').insert({
+    const { data, error } = await getSupabase().from('blog_posts').insert({
       id: slug,
       title: content.title,
       slug: slug,
@@ -108,7 +117,7 @@ export async function GET(request: NextRequest) {
     if (error) {
       console.error('Database error:', error)
       // Try with camelCase columns as fallback (Prisma schema uses camelCase)
-      const { data: data2, error: error2 } = await supabase.from('blog_posts').insert({
+      const { data: data2, error: error2 } = await getSupabase().from('blog_posts').insert({
         id: slug,
         title: content.title,
         slug: slug,
@@ -158,7 +167,7 @@ export async function GET(request: NextRequest) {
 async function pickUnusedTopic() {
   try {
     // Fetch recent post titles to avoid repetition
-    const { data: recentPosts } = await supabase
+    const { data: recentPosts } = await getSupabase()
       .from('blog_posts')
       .select('title')
       .order('created_at', { ascending: false })

--- a/app/api/retirement/calculations/route.ts
+++ b/app/api/retirement/calculations/route.ts
@@ -31,6 +31,19 @@ const calculationSchema = z.object({
     combinedMonthlyIncome: z.number().min(0).optional(),
     replacementRatio: z.number().min(0).max(2).optional(),
   }).optional(),
+  // Multi-group career segments. When present, the pension was calculated as a
+  // prorated benefit across multiple MA retirement groups. The retirementGroup
+  // field above stores the last/retirement segment's group for backward compat.
+  careerSegments: z
+    .array(
+      z.object({
+        group: z.enum(["1", "2", "3", "4"]),
+        yearsOfService: z.number().positive(),
+      }),
+    )
+    .min(2)
+    .max(2)
+    .optional(),
 })
 
 // GET - Retrieve all user's calculations
@@ -92,9 +105,10 @@ export async function GET(request: NextRequest) {
           createdAt: new Date("2024-01-15T10:30:00Z"),
           updatedAt: new Date("2024-01-15T10:30:00Z"),
           socialSecurityData: null,
+          careerSegments: null,
         },
         {
-          id: "mock-2", 
+          id: "mock-2",
           userId: session.user.id,
           calculationName: "Early Retirement - Age 62",
           retirementDate: new Date("2026-06-15"),
@@ -113,6 +127,7 @@ export async function GET(request: NextRequest) {
           createdAt: new Date("2024-01-10T14:15:00Z"),
           updatedAt: new Date("2024-01-10T14:15:00Z"),
           socialSecurityData: null,
+          careerSegments: null,
         },
         {
           id: "mock-3",
@@ -134,6 +149,7 @@ export async function GET(request: NextRequest) {
           createdAt: new Date("2024-01-08T09:45:00Z"),
           updatedAt: new Date("2024-01-08T09:45:00Z"),
           socialSecurityData: null,
+          careerSegments: null,
         },
         {
           id: "mock-4",
@@ -155,6 +171,7 @@ export async function GET(request: NextRequest) {
           createdAt: new Date("2024-01-05T16:20:00Z"),
           updatedAt: new Date("2024-01-05T16:20:00Z"),
           socialSecurityData: null,
+          careerSegments: null,
         },
         {
           id: "mock-5",
@@ -185,6 +202,7 @@ export async function GET(request: NextRequest) {
             combinedMonthlyIncome: 7265,
             replacementRatio: 0.85,
           }),
+          careerSegments: null,
         }
       ]
       
@@ -318,6 +336,7 @@ export async function POST(request: NextRequest) {
         notes: validatedData.notes,
         isFavorite: validatedData.isFavorite || false,
         socialSecurityData: validatedData.socialSecurityData ? JSON.stringify(validatedData.socialSecurityData) : null,
+        careerSegments: validatedData.careerSegments ?? undefined,
       }
     })
 

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -8,7 +8,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/auth-config'
 import { prisma } from '@/lib/prisma'
 import { StripeService } from '@/lib/stripe/service'
-import { SUBSCRIPTION_PLANS } from '@/lib/stripe/config'
+import { SUBSCRIPTION_PLANS, TRIAL_PERIOD_DAYS } from '@/lib/stripe/config'
 
 // Force dynamic rendering to prevent static generation issues with Prisma
 export const dynamic = 'force-dynamic'
@@ -101,13 +101,23 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // First-time customer heuristic: no prior subscriptionId and no active/past status.
+    // These users get the 14-day free trial. Returning subscribers go straight to paid.
+    const isFirstTimeCustomer =
+      !user.subscriptionId &&
+      (user.subscriptionStatus === null ||
+        user.subscriptionStatus === undefined ||
+        user.subscriptionStatus === 'free')
+    const trialDays = isFirstTimeCustomer ? TRIAL_PERIOD_DAYS : undefined
+
     // Create checkout session
     const checkoutUrl = await StripeService.createCheckoutSession(
       customerId,
       priceId,
       userEmail,
       successUrl,
-      cancelUrl
+      cancelUrl,
+      trialDays
     )
 
     console.log(`Created checkout session for ${userEmail}: ${checkoutUrl}`)

--- a/app/api/stripe/switch-plan/route.ts
+++ b/app/api/stripe/switch-plan/route.ts
@@ -1,0 +1,87 @@
+/**
+ * Stripe Switch Plan API
+ * Lets an authenticated monthly subscriber switch to the annual plan
+ * (or vice versa). Uses Stripe proration so the user is charged/credited
+ * for the difference. Powers the annual-upsell banner on the
+ * /subscription/portal page.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth/auth-config'
+import { prisma } from '@/lib/prisma'
+import { StripeService } from '@/lib/stripe/service'
+import { SUBSCRIPTION_PLANS } from '@/lib/stripe/config'
+
+export const dynamic = 'force-dynamic'
+
+interface SwitchPlanRequest {
+  targetPlan: 'monthly' | 'annual'
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { targetPlan } = (await request.json()) as SwitchPlanRequest
+    if (targetPlan !== 'monthly' && targetPlan !== 'annual') {
+      return NextResponse.json({ error: 'Invalid targetPlan' }, { status: 400 })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+    })
+
+    if (!user?.subscriptionId) {
+      return NextResponse.json(
+        { error: 'No active subscription to switch' },
+        { status: 400 }
+      )
+    }
+
+    if (user.subscriptionPlan === targetPlan) {
+      return NextResponse.json(
+        { error: `Already on the ${targetPlan} plan` },
+        { status: 400 }
+      )
+    }
+
+    const newPriceId =
+      targetPlan === 'annual'
+        ? SUBSCRIPTION_PLANS.annual.priceId
+        : SUBSCRIPTION_PLANS.monthly.priceId
+
+    const updated = await StripeService.updateSubscriptionPlan(
+      user.subscriptionId,
+      newPriceId
+    )
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        subscriptionPlan: targetPlan,
+        subscriptionStatus: updated.status,
+        currentPeriodEnd: updated.currentPeriodEnd,
+        cancelAtPeriodEnd: updated.cancelAtPeriodEnd,
+      },
+    })
+
+    return NextResponse.json({
+      success: true,
+      subscription: {
+        plan: targetPlan,
+        status: updated.status,
+        currentPeriodEnd: updated.currentPeriodEnd,
+      },
+    })
+  } catch (error: any) {
+    console.error('Switch plan failed:', error)
+    return NextResponse.json(
+      { error: 'Failed to switch plan', details: error?.message },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { headers } from 'next/headers'
 import { stripe, STRIPE_CONFIG, STRIPE_WEBHOOK_EVENTS, getSubscriptionPlan } from '@/lib/stripe/config'
 import { prisma } from '@/lib/prisma'
+import { emailService } from '@/lib/email/email-service'
 import type Stripe from 'stripe'
 
 // Force dynamic rendering to prevent static generation issues with Prisma
@@ -53,6 +54,10 @@ export async function POST(request: NextRequest) {
 
       case STRIPE_WEBHOOK_EVENTS.CUSTOMER_SUBSCRIPTION_DELETED:
         await handleSubscriptionDeleted(event.data.object as Stripe.Subscription)
+        break
+
+      case STRIPE_WEBHOOK_EVENTS.CUSTOMER_SUBSCRIPTION_TRIAL_WILL_END:
+        await handleTrialWillEnd(event.data.object as Stripe.Subscription)
         break
 
       case STRIPE_WEBHOOK_EVENTS.INVOICE_PAYMENT_SUCCEEDED:
@@ -167,6 +172,55 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
     console.log(`Updated user ${user.email} subscription: ${subscription.status}, plan: ${plan}`)
   } catch (error) {
     console.error('Error handling subscription updated:', error)
+    throw error
+  }
+}
+
+/**
+ * Handle trial-ending notification (fires ~3 days before trial ends).
+ * Sends a reminder email so the user can cancel or keep the subscription.
+ */
+async function handleTrialWillEnd(subscription: Stripe.Subscription) {
+  try {
+    const customerId = subscription.customer as string
+    const trialEnd = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null
+
+    const user = await prisma.user.findFirst({
+      where: { stripeCustomerId: customerId }
+    })
+
+    if (!user?.email) {
+      console.error(`User not found or missing email for Stripe customer: ${customerId}`)
+      return
+    }
+
+    const planLabel = getSubscriptionPlan(subscription.items.data[0]?.price.id || '')
+    const endsOn = trialEnd
+      ? trialEnd.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+      : 'soon'
+    const portalUrl = `${STRIPE_CONFIG.customerPortalUrl}`
+
+    await emailService.sendEmail({
+      to: user.email,
+      subject: `Your MassPension free trial ends ${endsOn}`,
+      html: `
+        <p>Hi${user.name ? ` ${user.name}` : ''},</p>
+        <p>Your 14-day MassPension Premium trial ends on <strong>${endsOn}</strong>. On that day, your ${planLabel} plan begins and your card will be charged.</p>
+        <p>Nothing to do if you want to continue — just keep using MassPension. To cancel before billing, visit your <a href="${portalUrl}">subscription portal</a>.</p>
+        <p>During your trial, remember to run:</p>
+        <ul>
+          <li>Your multi-group career calculation (if you've worked across Groups 1–4)</li>
+          <li>Social Security + WEP/GPO integration</li>
+          <li>Professional PDF retirement report</li>
+        </ul>
+        <p>— The MassPension team</p>
+      `,
+      text: `Your MassPension Premium trial ends ${endsOn}. Manage or cancel at ${portalUrl}.`,
+    })
+
+    console.log(`Sent trial_will_end email to ${user.email}`)
+  } catch (error) {
+    console.error('Error handling trial will end:', error)
     throw error
   }
 }

--- a/app/api/subscription/status/route.ts
+++ b/app/api/subscription/status/route.ts
@@ -38,6 +38,7 @@ interface SubscriptionResponse {
   currentPeriodEnd?: string
   cancelAtPeriodEnd?: boolean
   trialEnd?: string
+  hasUsedTrial?: boolean
   customerId?: string
   subscriptionId?: string
   usageLimits: {
@@ -118,6 +119,7 @@ export async function GET(request: NextRequest) {
             isSubscriptionActive(sub.status)
           ) || customer.subscriptions[0]
 
+          // If we see any subscription (active or historical), the user has already used their trial.
           subscriptionData = {
             isPremium: isSubscriptionActive(activeSubscription.status),
             subscriptionStatus: activeSubscription.status,
@@ -126,6 +128,7 @@ export async function GET(request: NextRequest) {
             currentPeriodEnd: safeToISOString(activeSubscription.currentPeriodEnd),
             cancelAtPeriodEnd: activeSubscription.cancelAtPeriodEnd,
             trialEnd: safeToISOString(activeSubscription.trialEnd),
+            hasUsedTrial: true,
             customerId: customer.id,
             subscriptionId: activeSubscription.id,
             usageLimits: getUsageLimits(activeSubscription.plan),
@@ -162,6 +165,7 @@ function getFreeUserData(user: any, calculationsCount: number): SubscriptionResp
     subscriptionStatus: 'inactive',
     subscriptionPlan: 'free',
     savedCalculationsCount: calculationsCount,
+    hasUsedTrial: Boolean(user?.subscriptionId) || user?.subscriptionStatus === 'canceled',
     usageLimits: getUsageLimits('free'),
     currentUsage: {
       savedCalculations: calculationsCount,

--- a/app/calculator/page.tsx
+++ b/app/calculator/page.tsx
@@ -12,6 +12,7 @@ import { ArrowRight, BookOpen, Users, DollarSign, Calculator, TrendingUp, FileTe
 import { Badge } from "@/components/ui/badge"
 import { Breadcrumbs } from "@/components/seo/breadcrumbs"
 import { RelatedTools } from "@/components/seo/related-tools"
+import { ExitIntentModal } from "@/components/premium/exit-intent-modal"
 
 export const metadata = generateSEOMetadata({
   title: "MA State Pension Calculator 2025 | Free MSRB Tool - Results in 60 Seconds",
@@ -261,6 +262,7 @@ export default function CalculatorPage() {
           <RelatedTools currentSlug="calculator" />
         </div>
       </div>
+      <ExitIntentModal />
     </>
   )
 }

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -12,6 +12,7 @@ import Link from "next/link"
 import { ResponsiveAd, PremiumAlternative } from "@/components/ads/adsense"
 import { AutoAds, SmartAds } from "@/components/ads/auto-ads"
 import { Breadcrumbs } from "@/components/seo/breadcrumbs"
+import { ExitIntentModal } from "@/components/premium/exit-intent-modal"
 
 // Feature-specific messaging
 const featureMessages = {
@@ -295,6 +296,7 @@ function PricingPageContent() {
           </div>
         </div>
       </main>
+      <ExitIntentModal />
     </div>
   )
 

--- a/app/social-security/page.tsx
+++ b/app/social-security/page.tsx
@@ -212,8 +212,7 @@ export default function SocialSecurityPage() {
       <div className="mb-12">
         <PremiumGate
           feature="social_security"
-          title="Social Security Benefit Integration"
-          description="Enter your official SSA.gov benefit estimates and combine them with your pension for comprehensive retirement planning"
+          variant="ss_limit"
           showPreview={false}
         >
           <SocialSecurityCalculator />

--- a/app/social-security/page.tsx
+++ b/app/social-security/page.tsx
@@ -7,6 +7,7 @@ import { Crown, DollarSign, TrendingUp, Calculator, Check, Users, ExternalLink, 
 import Link from "next/link"
 import { SocialSecurityCalculator } from "@/components/social-security/social-security-calculator"
 import { PremiumGate } from "@/components/premium/premium-gate"
+import { ExitIntentModal } from "@/components/premium/exit-intent-modal"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 
 export const metadata = generateSEOMetadata({
@@ -333,6 +334,7 @@ export default function SocialSecurityPage() {
         </CardContent>
       </Card>
     </div>
+    <ExitIntentModal />
     </>
   )
 }

--- a/app/subscription/portal/page.tsx
+++ b/app/subscription/portal/page.tsx
@@ -6,19 +6,20 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { 
-  CreditCard, 
-  Crown, 
-  Calendar, 
-  FileText, 
+import {
+  CreditCard,
+  Crown,
+  Calendar,
+  FileText,
   ExternalLink,
   AlertTriangle,
   CheckCircle,
   Loader2,
-  ArrowLeft
+  ArrowLeft,
+  Sparkles
 } from "lucide-react"
 import Link from "next/link"
-import { getSubscriptionDisplayStatus } from "@/lib/stripe/config"
+import { getSubscriptionDisplayStatus, SUBSCRIPTION_PLANS } from "@/lib/stripe/config"
 
 interface SubscriptionData {
   isPremium: boolean
@@ -49,6 +50,37 @@ export default function SubscriptionPortalPage() {
   const [loading, setLoading] = useState(true)
   const [portalLoading, setPortalLoading] = useState(false)
   const [stripeNotConfigured, setStripeNotConfigured] = useState(false)
+  const [switchingPlan, setSwitchingPlan] = useState(false)
+  const [switchError, setSwitchError] = useState<string | null>(null)
+
+  const handleSwitchToAnnual = async () => {
+    setSwitchingPlan(true)
+    setSwitchError(null)
+    try {
+      const response = await fetch('/api/stripe/switch-plan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetPlan: 'annual' }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data?.error || 'Failed to switch plan')
+      }
+
+      // Refresh subscription data so the banner disappears.
+      const statusResponse = await fetch('/api/subscription/status')
+      if (statusResponse.ok) {
+        const data = await statusResponse.json()
+        setSubscriptionData(data)
+      }
+    } catch (error: any) {
+      console.error('Switch to annual failed:', error)
+      setSwitchError(error?.message || 'Failed to switch plan')
+    } finally {
+      setSwitchingPlan(false)
+    }
+  }
 
   useEffect(() => {
     async function fetchData() {
@@ -288,6 +320,48 @@ export default function SubscriptionPortalPage() {
               Manage your subscription, billing, and payment information.
             </p>
           </div>
+
+          {/* Annual upsell banner: shown only when user is on the monthly plan. */}
+          {subscriptionData.subscriptionPlan === 'monthly' && !subscriptionData.cancelAtPeriodEnd && (
+            <Card className="mb-8 border-mrs-gold-400/40 bg-gradient-to-r from-mrs-gold-50 to-amber-50 dark:from-mrs-gold-500/10 dark:to-amber-500/10">
+              <CardContent className="py-5 flex flex-col md:flex-row md:items-center gap-4 md:gap-6">
+                <div className="flex items-start gap-3 flex-1">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mrs-gold-500/20">
+                    <Sparkles className="h-5 w-5 text-mrs-gold-700 dark:text-mrs-gold-400" />
+                  </div>
+                  <div>
+                    <div className="font-semibold text-slate-900 dark:text-white">
+                      Switch to annual and save $13.89/year
+                    </div>
+                    <div className="text-sm text-slate-600 dark:text-slate-300 mt-1">
+                      Monthly: ${(SUBSCRIPTION_PLANS.monthly.price * 12).toFixed(2)}/yr · Annual: ${SUBSCRIPTION_PLANS.annual.price}/yr.
+                      Stripe prorates the change automatically — you're credited for the unused portion of this month.
+                    </div>
+                    {switchError && (
+                      <div className="text-sm text-red-600 dark:text-red-400 mt-2">{switchError}</div>
+                    )}
+                  </div>
+                </div>
+                <Button
+                  onClick={handleSwitchToAnnual}
+                  disabled={switchingPlan}
+                  className="bg-gradient-to-r from-mrs-gold-500 to-mrs-gold-600 hover:from-mrs-gold-400 hover:to-mrs-gold-500 text-white font-bold shadow-md shrink-0"
+                >
+                  {switchingPlan ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Switching...
+                    </>
+                  ) : (
+                    <>
+                      <Crown className="mr-2 h-4 w-4" />
+                      Switch to Annual
+                    </>
+                  )}
+                </Button>
+              </CardContent>
+            </Card>
+          )}
 
           <div className="grid lg:grid-cols-2 gap-8">
             {/* Subscription Details */}

--- a/app/wizard/page.tsx
+++ b/app/wizard/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react"
 import { CombinedCalculationWizard } from "@/components/wizard/combined-calculation-wizard"
 import { PremiumGate } from "@/components/premium/premium-gate"
+import { ExitIntentModal } from "@/components/premium/exit-intent-modal"
 import { CombinedCalculationData } from "@/lib/wizard/wizard-types"
 
 export default function WizardPage() {
@@ -334,6 +335,7 @@ export default function WizardPage() {
           </div>
         </CardContent>
       </Card>
+      <ExitIntentModal />
     </div>
   )
 }

--- a/components/pension-calculator.tsx
+++ b/components/pension-calculator.tsx
@@ -21,7 +21,9 @@ import {
   checkEligibility,
   getBenefitFactor,
   generateProjectionTable,
+  calculateMultiGroupPension,
 } from "@/lib/pension-calculations"
+import { FREE_TIER_LIMITS } from "@/lib/stripe/config"
 import { parseGroupParam, getDefaultRetirementAge as getGroupDefaultAge } from "@/lib/utils/group-param-parser"
 import EligibilityInfo from "./eligibility-info"
 import PensionResults from "./pension-results"
@@ -121,6 +123,12 @@ export default function PensionCalculator() {
     currentAge: "",
     membershipDate: "",
     additionalService: "",
+    // Multi-group career support (V1: up to 2 segments). The main `group` field
+    // above represents the retirement group (last segment); `secondaryGroup`
+    // captures earlier service in a different group.
+    enableMultiGroup: false,
+    secondaryGroup: "",
+    secondaryGroupYears: "",
   })
 
   const [showNotification, setShowNotification] = useState(false)
@@ -311,6 +319,9 @@ export default function PensionCalculator() {
         currentAge: "",
         membershipDate: "",
         additionalService: "",
+        enableMultiGroup: false,
+        secondaryGroup: "",
+        secondaryGroupYears: "",
       }
 
       setFormData(widgetFormData)
@@ -521,6 +532,9 @@ export default function PensionCalculator() {
         currentAge: "",
         membershipDate: "",
         additionalService: "",
+        enableMultiGroup: false,
+        secondaryGroup: "",
+        secondaryGroupYears: "",
       })
       setIsFormDirty(false)
       setShowNotification(false)
@@ -702,6 +716,107 @@ export default function PensionCalculator() {
       const enteredYOS = Number.parseFloat(formData.yearsOfService)
       const group = formData.group
       const serviceEntry = formData.serviceEntryDate
+
+      // Multi-group career path: 5 yrs Group 4 + 30 yrs Group 2 = 12.5% + 60% = 72.5%
+      // See calculateMultiGroupPension() in lib/pension-calculations.ts.
+      if (formData.enableMultiGroup && formData.secondaryGroup && formData.secondaryGroupYears) {
+        // Soft paywall: free tier gets one multi-group preview calc, tracked in localStorage.
+        const LIMIT = FREE_TIER_LIMITS.maxMultiGroupCalculations
+        const USAGE_KEY = "masspension_multi_group_used_count"
+        const prevCount = typeof window !== "undefined"
+          ? Number.parseInt(localStorage.getItem(USAGE_KEY) || "0", 10) || 0
+          : 0
+        if (!isPremium && prevCount >= LIMIT) {
+          setErrors([
+            "You've used your free multi-group calculation. Upgrade to Premium to run unlimited multi-group scenarios — the only MA tool that correctly handles career transitions between Groups 1–4.",
+          ])
+          setIsCalculating(false)
+          return
+        }
+
+        const secondaryYears = Number.parseFloat(formData.secondaryGroupYears)
+        const primaryYears = enteredYOS - secondaryYears
+        if (Number.isNaN(secondaryYears) || secondaryYears <= 0 || primaryYears <= 0) {
+          setErrors([
+            "Years in the earlier group must be positive and less than your total years of service.",
+          ])
+          setIsCalculating(false)
+          return
+        }
+        if (formData.secondaryGroup === group) {
+          setErrors(["Earlier group must be different from your retirement group."])
+          setIsCalculating(false)
+          return
+        }
+
+        const salary1 = Number.parseFloat(formData.salary1)
+        const salary2 = Number.parseFloat(formData.salary2)
+        const salary3 = Number.parseFloat(formData.salary3)
+        const averageSalary = (salary1 + salary2 + salary3) / 3
+
+        const multiResult = calculateMultiGroupPension(
+          [
+            { group: formData.secondaryGroup, yearsOfService: secondaryYears },
+            { group, yearsOfService: primaryYears },
+          ],
+          enteredAge,
+          averageSalary,
+          formData.retirementOption as "A" | "B" | "C",
+          serviceEntry,
+          formData.beneficiaryAge,
+        )
+
+        if (!multiResult.eligible) {
+          setEligibilityWarning(
+            multiResult.eligibilityMessage ||
+              "Combined service does not meet retirement eligibility requirements.",
+          )
+          setIsCalculating(false)
+          return
+        }
+
+        if (typeof window !== "undefined") {
+          localStorage.setItem(USAGE_KEY, String(prevCount + 1))
+        }
+
+        // Projection table uses the retirement group (last segment) with total YOS.
+        const projectionData = generateProjectionTable(
+          group,
+          enteredAge,
+          enteredYOS,
+          averageSalary,
+          formData.retirementOption,
+          formData.beneficiaryAge,
+          serviceEntry,
+        )
+
+        setCalculationResult({
+          selectedOption: multiResult.optionDescription,
+          optionWarning: multiResult.optionWarning,
+          annualPension: multiResult.annualPension,
+          monthlyPension: multiResult.monthlyPension,
+          survivorAnnualPension: multiResult.survivorAnnualPension,
+          survivorMonthlyPension: multiResult.survivorMonthlyPension,
+          retirementOption: formData.retirementOption,
+          beneficiaryAge: formData.beneficiaryAge,
+          details: {
+            averageSalary,
+            group,
+            age: enteredAge,
+            yearsOfService: enteredYOS,
+            basePercentage: multiResult.basePercentage * 100,
+            baseAnnualPension: multiResult.baseAnnualPension,
+            cappedBase: multiResult.cappedBase,
+            careerSegments: multiResult.segmentBreakdown,
+          },
+          projectionData,
+        })
+
+        setShowResults(true)
+        setCurrentStep(2)
+        setIsCalculating(false)
+        return
+      }
 
       // Check eligibility
       const eligibility = checkEligibility(Math.floor(enteredAge), enteredYOS, group, serviceEntry)
@@ -1027,6 +1142,73 @@ export default function PensionCalculator() {
                       </SelectContent>
                     </Select>
                   </div>
+                </div>
+
+                <div className="mt-4 border-t border-green-200 dark:border-green-800 pt-4">
+                  <div className="flex items-center gap-2">
+                    <input
+                      id="enableMultiGroup"
+                      type="checkbox"
+                      checked={!!formData.enableMultiGroup}
+                      onChange={(e) =>
+                        setFormData({ ...formData, enableMultiGroup: e.target.checked })
+                      }
+                      className="h-4 w-4 rounded border-green-300 text-green-600 focus:ring-green-500"
+                    />
+                    <Label htmlFor="enableMultiGroup" className="cursor-pointer">
+                      I worked in multiple groups during my career
+                    </Label>
+                    {!isPremium && (
+                      <Badge variant="secondary" className="bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                        <Crown className="mr-1 h-3 w-3" />
+                        1 free preview
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="mt-2 text-xs text-green-800 dark:text-green-200">
+                    Example: 5 years in Group 4 (corrections) + 30 years in Group 2 at age 55 = 12.5% + 60% = 72.5% of
+                    average salary. Each segment earns its group&apos;s benefit factor; the 80% cap applies to the combined
+                    benefit.
+                  </p>
+
+                  {formData.enableMultiGroup && (
+                    <div className="mt-4 grid gap-4 rounded-lg bg-white dark:bg-green-950/30 p-4 border border-green-200 dark:border-green-800">
+                      <div className="space-y-2">
+                        <Label htmlFor="secondaryGroup">Earlier group (before your retirement group)</Label>
+                        <Select
+                          value={formData.secondaryGroup || ""}
+                          onValueChange={(value) => handleSelectChange("secondaryGroup", value)}
+                        >
+                          <SelectTrigger id="secondaryGroup">
+                            <SelectValue placeholder="Select earlier group" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="GROUP_1">Group I (General Employees)</SelectItem>
+                            <SelectItem value="GROUP_2">Group II (Probation/Court Officers)</SelectItem>
+                            <SelectItem value="GROUP_3">Group III (MA State Police ONLY)</SelectItem>
+                            <SelectItem value="GROUP_4">Group IV (Municipal Police/Fire/Corrections)</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="secondaryGroupYears">Years worked in the earlier group</Label>
+                        <Input
+                          id="secondaryGroupYears"
+                          name="secondaryGroupYears"
+                          type="number"
+                          min="0"
+                          step="0.5"
+                          placeholder="e.g., 5"
+                          value={formData.secondaryGroupYears}
+                          onChange={handleInputChange}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Your total years of service above must include these earlier years. The remainder is applied
+                          to your retirement group.
+                        </p>
+                      </div>
+                    </div>
+                  )}
                 </div>
               </fieldset>
 

--- a/components/pension-calculator.tsx
+++ b/components/pension-calculator.tsx
@@ -36,6 +36,7 @@ import { useSession } from "next-auth/react"
 import { useRetirementData } from "@/hooks/use-retirement-data"
 import { useSubscriptionStatus } from "@/hooks/use-subscription"
 import { EnhancedPremiumGate } from "@/components/premium/enhanced-premium-gate"
+import { UsageBanner } from "@/components/premium/usage-banner"
 import {
   Dialog,
   DialogContent,
@@ -2182,6 +2183,16 @@ export default function PensionCalculator() {
 
   return (
     <>
+      {/* Approaching-limit nudge: shown when user is 1 away from or at the saves limit. */}
+      {!isPremium && (
+        <UsageBanner
+          feature="saves"
+          currentUsage={savedCalculationsCount}
+          limit={maxSavedCalculations === Infinity ? 0 : maxSavedCalculations}
+          className="mb-4"
+        />
+      )}
+
       {/* Mobile-First Layout: Calculator Form First */}
       <div className="lg:hidden">
         {/* Mobile: Calculator Form Card - Appears First */}

--- a/components/premium/exit-intent-modal.tsx
+++ b/components/premium/exit-intent-modal.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Badge } from "@/components/ui/badge"
+import { Sparkles, Crown } from "lucide-react"
+import { useSubscriptionStatus } from "@/hooks/use-subscription"
+
+const SESSION_KEY = "masspension_exit_intent_shown"
+const PROMO_CODE = "STAY20"
+
+/**
+ * Shows once per browser session when a free user's cursor leaves the top
+ * of the viewport (typical close-tab intent). Offers a 20% promo code
+ * (STAY20) redeemable at checkout via allow_promotion_codes. Premium
+ * users and users who've already dismissed the modal this session are
+ * excluded.
+ */
+export function ExitIntentModal() {
+  const { isPremium } = useSubscriptionStatus()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (isPremium) return
+    if (sessionStorage.getItem(SESSION_KEY) === "1") return
+
+    // Arm only after a short dwell so we don't fire on accidental top-nav hovers
+    let armed = false
+    const dwellTimer = window.setTimeout(() => {
+      armed = true
+    }, 5000)
+
+    const handleMouseLeave = (event: MouseEvent) => {
+      if (!armed) return
+      if (event.clientY > 10) return
+      if (sessionStorage.getItem(SESSION_KEY) === "1") return
+      sessionStorage.setItem(SESSION_KEY, "1")
+      setOpen(true)
+    }
+
+    document.addEventListener("mouseleave", handleMouseLeave)
+    return () => {
+      document.removeEventListener("mouseleave", handleMouseLeave)
+      window.clearTimeout(dwellTimer)
+    }
+  }, [isPremium])
+
+  const handleCopyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(PROMO_CODE)
+    } catch (error) {
+      console.warn("Failed to copy promo code:", error)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <Badge className="w-fit mb-2 bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+            <Sparkles className="mr-1 h-3 w-3" />
+            Before you go
+          </Badge>
+          <DialogTitle className="text-2xl">
+            20% off your first month of Premium
+          </DialogTitle>
+          <DialogDescription>
+            Start the 14-day free trial today and use promo code{" "}
+            <button
+              type="button"
+              onClick={handleCopyCode}
+              className="inline-flex items-center font-mono font-bold bg-amber-100 dark:bg-amber-900/50 text-amber-900 dark:text-amber-200 rounded px-2 py-0.5 hover:bg-amber-200 dark:hover:bg-amber-900 transition-colors"
+              aria-label="Copy promo code STAY20"
+            >
+              {PROMO_CODE}
+            </button>{" "}
+            at checkout for 20% off your first month if you continue past the trial.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-2 text-sm text-muted-foreground space-y-2">
+          <p>
+            Premium unlocks unlimited saves, the multi-group career
+            calculator, Social Security + WEP/GPO optimization, and
+            professional PDF reports.
+          </p>
+          <p className="text-xs">
+            No card charged during your 14-day trial · Cancel anytime.
+          </p>
+        </div>
+        <DialogFooter className="flex-col sm:flex-row gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            className="w-full sm:w-auto"
+          >
+            No thanks
+          </Button>
+          <Button asChild className="w-full sm:w-auto">
+            <Link href="/pricing" onClick={() => setOpen(false)}>
+              <Crown className="mr-2 h-4 w-4" />
+              Start Free Trial
+            </Link>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/premium/premium-gate.tsx
+++ b/components/premium/premium-gate.tsx
@@ -8,11 +8,80 @@ import { Crown, Lock } from "lucide-react"
 import Link from "next/link"
 import { useSubscriptionStatus } from "@/hooks/use-subscription"
 import { logPremium } from "@/lib/utils/debug"
+import { FREE_TIER_LIMITS } from "@/lib/stripe/config"
+
+type PaywallVariant =
+  | "saves_limit"
+  | "ss_limit"
+  | "wizard"
+  | "pdf"
+  | "multi_group"
+  | "generic"
+
+interface VariantCopy {
+  badge: string
+  title: string
+  description: string
+  highlight?: string
+  primaryCta: string
+}
+
+const VARIANT_COPY: Record<PaywallVariant, VariantCopy> = {
+  saves_limit: {
+    badge: "You've hit your save limit",
+    title: `${FREE_TIER_LIMITS.maxSavedCalculations} of ${FREE_TIER_LIMITS.maxSavedCalculations} free saves used`,
+    description:
+      "Your prior calculations are still here — start a 14-day free trial to save unlimited scenarios and compare them side-by-side.",
+    highlight: "Most users save 5–8 scenarios before making a final retirement decision.",
+    primaryCta: "Start 14-Day Free Trial",
+  },
+  ss_limit: {
+    badge: "Unlock multi-scenario Social Security",
+    title: "Compare more than one Social Security scenario",
+    description:
+      "You've used your free Social Security calculation. Premium unlocks unlimited scenarios so you can model early vs. full vs. delayed claiming — typical difference is $400–$1,200 /month.",
+    highlight: "WEP/GPO impact on MA state employees can reduce SS by up to 50%. Model it before you file.",
+    primaryCta: "Start 14-Day Free Trial",
+  },
+  wizard: {
+    badge: "Full guided analysis",
+    title: "The Combined Retirement Wizard is Premium",
+    description:
+      "The wizard walks you through pension, Social Security, taxes, and COLA in one guided flow — and flags optimizations most users miss on their first calculation.",
+    highlight: "Covers Option A/B/C tradeoffs, WEP/GPO, and tax-withdrawal sequencing in ~8 minutes.",
+    primaryCta: "Start 14-Day Free Trial",
+  },
+  pdf: {
+    badge: "Professional PDF report",
+    title: "Download your retirement report",
+    description:
+      "Premium generates a shareable PDF with your pension math, Social Security integration, COLA projections, and tax estimates — ready to hand to your spouse, CPA, or financial advisor.",
+    highlight: "Most advisors charge $400+ to produce an equivalent retirement report.",
+    primaryCta: "Start 14-Day Free Trial",
+  },
+  multi_group: {
+    badge: "Multi-group career calculation",
+    title: "You've run your free multi-group calculation",
+    description:
+      "Premium unlocks unlimited multi-group scenarios — MassPension is the only MA tool that correctly prorates benefits across career transitions between Groups 1–4.",
+    highlight:
+      "Example: 5 years Group 4 corrections + 30 years Group 2 mental health = combined 72.5% of average salary, not what either MSRB single-group calc would show.",
+    primaryCta: "Start 14-Day Free Trial",
+  },
+  generic: {
+    badge: "Premium Feature",
+    title: "Unlock this feature",
+    description:
+      "Upgrade to Premium to unlock this feature and the complete MassPension toolkit.",
+    primaryCta: "Start 14-Day Free Trial",
+  },
+}
 
 interface PremiumGateProps {
   feature: string
-  title: string
-  description: string
+  title?: string
+  description?: string
+  variant?: PaywallVariant
   children: ReactNode
   fallback?: ReactNode
   showPreview?: boolean
@@ -22,6 +91,7 @@ export function PremiumGate({
   feature,
   title,
   description,
+  variant = "generic",
   children,
   fallback,
   showPreview = false
@@ -49,6 +119,10 @@ export function PremiumGate({
     return <>{fallback}</>
   }
 
+  const copy = VARIANT_COPY[variant] ?? VARIANT_COPY.generic
+  const resolvedTitle = title ?? copy.title
+  const resolvedDescription = description ?? copy.description
+
   return (
     <Card className="relative overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/20 dark:to-orange-950/20" />
@@ -59,26 +133,31 @@ export function PremiumGate({
           </div>
           <Badge variant="secondary" className="mx-auto mb-2 bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
             <Lock className="mr-1 h-3 w-3" />
-            Premium Feature
+            {copy.badge}
           </Badge>
-          <CardTitle className="text-xl">{title}</CardTitle>
-          <CardDescription>{description}</CardDescription>
+          <CardTitle className="text-xl">{resolvedTitle}</CardTitle>
+          <CardDescription>{resolvedDescription}</CardDescription>
         </CardHeader>
         <CardContent className="text-center space-y-4">
           {showPreview && (
-            <div className="opacity-50 pointer-events-none">
+            <div className="opacity-50 pointer-events-none blur-[2px] select-none">
               {children}
             </div>
           )}
           <div className="space-y-3">
+            {copy.highlight && (
+              <p className="text-sm font-medium text-amber-900 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900/40 rounded-md px-3 py-2">
+                {copy.highlight}
+              </p>
+            )}
             <p className="text-sm text-muted-foreground">
-              Upgrade to Premium to unlock this feature and many more advanced retirement planning tools.
+              14-day free trial · No card charged today · Cancel anytime from your portal.
             </p>
             <div className="flex flex-col sm:flex-row gap-2 justify-center">
               <Button asChild>
-                <Link href="/subscribe">
+                <Link href="/pricing">
                   <Crown className="mr-2 h-4 w-4" />
-                  Upgrade to Premium
+                  {copy.primaryCta}
                 </Link>
               </Button>
               <Button variant="outline" asChild>

--- a/components/premium/usage-banner.tsx
+++ b/components/premium/usage-banner.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import Link from "next/link"
+import { AlertCircle, Crown } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+
+type UsageFeature = "saves" | "social_security" | "multi_group"
+
+interface UsageBannerProps {
+  feature: UsageFeature
+  currentUsage: number
+  limit: number
+  className?: string
+}
+
+const FEATURE_COPY: Record<UsageFeature, { name: string; cta: string }> = {
+  saves: {
+    name: "saved calculation",
+    cta: "Unlock unlimited saves",
+  },
+  social_security: {
+    name: "Social Security calculation",
+    cta: "Unlock unlimited SS scenarios",
+  },
+  multi_group: {
+    name: "multi-group calculation",
+    cta: "Unlock unlimited multi-group scenarios",
+  },
+}
+
+export function UsageBanner({
+  feature,
+  currentUsage,
+  limit,
+  className,
+}: UsageBannerProps) {
+  if (limit <= 0 || currentUsage < limit - 1) {
+    return null
+  }
+
+  const atLimit = currentUsage >= limit
+  const copy = FEATURE_COPY[feature]
+
+  return (
+    <Alert
+      className={`border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900/40 ${className ?? ""}`}
+    >
+      <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+      <AlertDescription className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-amber-900 dark:text-amber-200">
+        <span className="text-sm">
+          {atLimit ? (
+            <>
+              <strong>
+                {currentUsage} of {limit} free {copy.name}s used.
+              </strong>{" "}
+              Start a free trial to continue.
+            </>
+          ) : (
+            <>
+              <strong>Last free {copy.name} remaining.</strong> Start a free
+              trial to keep going without limits.
+            </>
+          )}
+        </span>
+        <Button
+          asChild
+          size="sm"
+          className="bg-amber-600 hover:bg-amber-700 text-white shrink-0"
+        >
+          <Link href="/pricing">
+            <Crown className="mr-2 h-3 w-3" />
+            {copy.cta}
+          </Link>
+        </Button>
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/components/pricing/pricing-section.tsx
+++ b/components/pricing/pricing-section.tsx
@@ -14,6 +14,7 @@ interface SubscriptionData {
   isPremium: boolean
   subscriptionPlan: string
   subscriptionStatus: string
+  hasUsedTrial?: boolean
 }
 
 const features = {
@@ -55,6 +56,12 @@ export function PricingSection() {
   const [subscriptionData, setSubscriptionData] = useState<SubscriptionData | null>(null)
   const [loading, setLoading] = useState(true)
   const [checkoutLoading, setCheckoutLoading] = useState<string | null>(null)
+
+  // A logged-in user who has never subscribed qualifies for the 14-day free trial.
+  const trialEligible =
+    !!session?.user &&
+    !subscriptionData?.isPremium &&
+    !subscriptionData?.hasUsedTrial
 
   useEffect(() => {
     async function fetchSubscriptionData() {
@@ -218,12 +225,14 @@ export function PricingSection() {
                   </>
                 ) : subscriptionData?.isPremium ? (
                   'Current Plan'
+                ) : trialEligible ? (
+                  'Start 14-Day Free Trial'
                 ) : (
                   'Choose Monthly'
                 )}
               </Button>
               <p className="text-xs text-center text-slate-400 mt-4 font-medium uppercase tracking-widest">
-                Cancel anytime
+                {trialEligible ? 'No card charged today · Cancel anytime' : 'Cancel anytime'}
               </p>
             </div>
           </Card>
@@ -273,12 +282,14 @@ export function PricingSection() {
                   </>
                 ) : subscriptionData?.isPremium ? (
                   'Current Plan'
+                ) : trialEligible ? (
+                  'Start 14-Day Free Trial'
                 ) : (
                   'Choose Annual'
                 )}
               </Button>
               <p className="text-[10px] text-center text-slate-400 mt-4 font-bold uppercase tracking-widest">
-                30-day money-back guarantee
+                {trialEligible ? 'No card charged today · 30-day money-back guarantee' : '30-day money-back guarantee'}
               </p>
             </div>
           </Card>

--- a/hooks/use-subscription.ts
+++ b/hooks/use-subscription.ts
@@ -164,12 +164,13 @@ export function useSubscriptionStatus() {
   const upgradeRequired = (feature: string): boolean => {
     const isUpgradeRequired = !subscriptionData.isPremium && [
       'unlimited_saves',
-      'pdf_export', 
+      'pdf_export',
       'excel_export',
       'advanced_scenarios',
       'comparison_tools',
       'social_security',
-      '401k_integration'
+      '401k_integration',
+      'multi_group'
     ].includes(feature)
     
     console.log(`upgradeRequired(${feature}): isPremium=${subscriptionData.isPremium}, required=${isUpgradeRequired}`)

--- a/lib/pension-calculations.ts
+++ b/lib/pension-calculations.ts
@@ -559,6 +559,137 @@ export function calculateAnnualPension(
   return optionResult.pension
 }
 
+/**
+ * A single segment of a multi-group career.
+ * Example: { group: "GROUP_4", yearsOfService: 5 } means 5 years worked in Group 4.
+ */
+export interface CareerSegment {
+  group: string
+  yearsOfService: number
+}
+
+export interface MultiGroupPensionResult {
+  annualPension: number
+  monthlyPension: number
+  survivorAnnualPension: number
+  survivorMonthlyPension: number
+  basePercentage: number
+  baseAnnualPension: number
+  cappedBase: boolean
+  eligible: boolean
+  eligibilityMessage: string
+  optionDescription: string
+  optionWarning: string
+  retirementGroup: string
+  totalYearsOfService: number
+  segmentBreakdown: Array<{
+    group: string
+    yearsOfService: number
+    benefitFactor: number
+    segmentPercentage: number
+  }>
+}
+
+/**
+ * Calculate a prorated MA pension for a career that spans multiple groups.
+ *
+ * Per MGL c. 32 §3(2)(f), each segment earns its own benefit factor based on
+ * (group, retirement age), the per-segment percentages sum, the 80% cap is
+ * applied to the combined benefit, and option/veteran adjustments are applied
+ * to the combined base using the retirement group (the last segment).
+ *
+ * Eligibility uses the retirement group (last segment) for minimum age and
+ * the sum of segment years for minimum service.
+ *
+ * V1 scope: supports 1..N segments with a shared serviceEntry and shared
+ * average salary. Total segment years are used when determining whether the
+ * pre-2012 factor table applies (the 30+ YOS exception).
+ */
+export function calculateMultiGroupPension(
+  segments: CareerSegment[],
+  retirementAge: number,
+  averageSalary: number,
+  option: "A" | "B" | "C" = "A",
+  serviceEntry: string = "before_2012",
+  beneficiaryAgeStr: string = "",
+  isVeteran: boolean = false,
+): MultiGroupPensionResult {
+  const retirementGroup = segments.length > 0 ? segments[segments.length - 1].group : "GROUP_2"
+  const totalYearsOfService = segments.reduce((sum, s) => sum + s.yearsOfService, 0)
+
+  const eligibility = checkEligibility(Math.floor(retirementAge), totalYearsOfService, retirementGroup, serviceEntry)
+
+  const segmentBreakdown = segments.map(seg => {
+    const factor = getBenefitFactor(Math.floor(retirementAge), seg.group, serviceEntry, totalYearsOfService)
+    return {
+      group: seg.group,
+      yearsOfService: seg.yearsOfService,
+      benefitFactor: factor,
+      segmentPercentage: factor * seg.yearsOfService,
+    }
+  })
+
+  if (!eligibility.eligible || segmentBreakdown.some(s => s.benefitFactor === 0)) {
+    return {
+      annualPension: 0,
+      monthlyPension: 0,
+      survivorAnnualPension: 0,
+      survivorMonthlyPension: 0,
+      basePercentage: 0,
+      baseAnnualPension: 0,
+      cappedBase: false,
+      eligible: false,
+      eligibilityMessage: eligibility.eligible
+        ? "One or more segments has no applicable benefit factor at the retirement age."
+        : eligibility.message,
+      optionDescription: "",
+      optionWarning: "",
+      retirementGroup,
+      totalYearsOfService,
+      segmentBreakdown,
+    }
+  }
+
+  let basePercentage = segmentBreakdown.reduce((sum, s) => sum + s.segmentPercentage, 0)
+  let baseAnnualPension = averageSalary * basePercentage
+  const maxPension = averageSalary * MAX_PENSION_PERCENTAGE_OF_SALARY
+  let cappedBase = false
+  if (baseAnnualPension > maxPension) {
+    baseAnnualPension = maxPension
+    basePercentage = MAX_PENSION_PERCENTAGE_OF_SALARY
+    cappedBase = true
+  }
+  if (baseAnnualPension < 0) baseAnnualPension = 0
+
+  const veteranBenefit = calculateVeteranBenefit(isVeteran, retirementAge, totalYearsOfService)
+  const pensionWithVeteran = baseAnnualPension + veteranBenefit
+
+  const optionResult = calculatePensionWithOption(
+    pensionWithVeteran,
+    option,
+    retirementAge,
+    beneficiaryAgeStr,
+    retirementGroup,
+  )
+
+  return {
+    annualPension: optionResult.pension,
+    monthlyPension: optionResult.pension / 12,
+    survivorAnnualPension: optionResult.survivorPension,
+    survivorMonthlyPension: optionResult.survivorPension / 12,
+    basePercentage,
+    baseAnnualPension,
+    cappedBase,
+    eligible: true,
+    eligibilityMessage: "",
+    optionDescription: optionResult.description,
+    optionWarning: optionResult.warning,
+    retirementGroup,
+    totalYearsOfService,
+    segmentBreakdown,
+  }
+}
+
 	// ---------------------------------------------------------------------------
 	// Legacy-compatible types & helper functions
 	// ---------------------------------------------------------------------------

--- a/lib/stripe/config.ts
+++ b/lib/stripe/config.ts
@@ -349,6 +349,7 @@ export const STRIPE_WEBHOOK_EVENTS = {
   CUSTOMER_SUBSCRIPTION_CREATED: 'customer.subscription.created',
   CUSTOMER_SUBSCRIPTION_UPDATED: 'customer.subscription.updated',
   CUSTOMER_SUBSCRIPTION_DELETED: 'customer.subscription.deleted',
+  CUSTOMER_SUBSCRIPTION_TRIAL_WILL_END: 'customer.subscription.trial_will_end',
   INVOICE_PAYMENT_SUCCEEDED: 'invoice.payment_succeeded',
   INVOICE_PAYMENT_FAILED: 'invoice.payment_failed',
   CUSTOMER_CREATED: 'customer.created',

--- a/lib/stripe/config.ts
+++ b/lib/stripe/config.ts
@@ -65,6 +65,7 @@ export const FREE_TIER_LIMITS = {
   maxSocialSecurityCalculations: 1,
   maxWizardUses: 0, // No wizard access for free users
   maxPdfReports: 0,
+  maxMultiGroupCalculations: 1, // 1 free preview of the multi-group (career-transition) calculator
   features: [
     'Basic pension calculator',
     'Limited calculation history',
@@ -115,6 +116,13 @@ export const PREMIUM_FEATURES = {
     description: 'Advanced tax planning and withdrawal strategies',
     required: true,
     freeLimit: 0,
+    premiumUnlimited: true
+  },
+  multi_group: {
+    name: 'Multi-Group Career Calculator',
+    description: 'Prorated pension calculation for careers that span multiple MA retirement groups (e.g., 5 years in Group 4 corrections plus 30 years in Group 2). Free tier includes one preview calculation.',
+    required: true,
+    freeLimit: 1,
     premiumUnlimited: true
   }
 } as const

--- a/lib/stripe/service.ts
+++ b/lib/stripe/service.ts
@@ -54,13 +54,24 @@ export class StripeService {
     priceId: string,
     userEmail: string,
     successUrl?: string,
-    cancelUrl?: string
+    cancelUrl?: string,
+    trialPeriodDays?: number
   ): Promise<string> {
     if (!stripe) {
       throw new StripeError('Stripe is not configured. Please add STRIPE_SECRET_KEY to environment variables.')
     }
 
     try {
+      const subscriptionData: Record<string, unknown> = {
+        metadata: {
+          user_email: userEmail,
+          plan: getSubscriptionPlan(priceId),
+        },
+      }
+      if (trialPeriodDays && trialPeriodDays > 0) {
+        subscriptionData.trial_period_days = trialPeriodDays
+      }
+
       const session = await stripe.checkout.sessions.create({
         customer: customerId,
         payment_method_types: ['card'],
@@ -83,13 +94,8 @@ export class StripeService {
           user_email: userEmail,
           plan: getSubscriptionPlan(priceId),
         },
-        subscription_data: {
-          metadata: {
-            user_email: userEmail,
-            plan: getSubscriptionPlan(priceId),
-          },
-        },
-      })
+        subscription_data: subscriptionData,
+      } as any)
 
       if (!session.url) {
         throw new StripeError('Failed to create checkout session URL')

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -386,6 +386,7 @@ model RetirementCalculation {
   benefitReduction   Float?
   survivorBenefit    Float?
   socialSecurityData String?
+  careerSegments     Json?
   notes              String?
   isFavorite         Boolean  @default(false)
   createdAt          DateTime @default(now())


### PR DESCRIPTION
## Summary

- **P0** — 14-day free trial for first-time Stripe customers; `trial_will_end` webhook triggers Resend email 3 days before billing
- **P1** — Contextual paywall variants (`saves_limit`, `ss_limit`, `wizard`, `pdf`, `multi_group`, `generic`) with variant-specific copy and blurred preview UX
- **P1b** — Multi-group MA pension calculator: career transitions across Groups 1–4, 80% cap, correct per-segment benefit factors, 30-YOS rule on total service
- **P4** — Exit-intent modal with STAY20 promo code (sessionStorage-gated, 5s dwell, fires on cursor leaving viewport top); mounted on `/calculator`, `/social-security`, `/wizard`, `/pricing`
- **P5** — Monthly→annual upsell banner on `/subscription/portal` calling existing `updateSubscriptionPlan`
- **P7** — Approaching-limit inline usage banner (fires when `currentUsage >= limit - 1`)
- **Build fix** — Lazy-init Supabase client in `/api/cron/auto-blog` so `next build` no longer fails "Collecting page data" when env vars aren't injected at build time

## Post-merge checklist
- [ ] Confirm Vercel env vars are set for Production: `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `DATABASE_URL`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `RESEND_API_KEY`, `CRON_SECRET`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GEMINI_API_KEY`
- [ ] Create **STAY20** promo code in Stripe dashboard (20% off, applies to first month)
- [ ] Run `prisma migrate deploy` for the `careerSegments Json?` column on `RetirementCalculation`

https://claude.ai/code/session_01NQsNPGoFoSYzkj7SCmL6BN