### PR TITLE
fix: multi-group projection table uses blended base% (not single-group)

### DIFF
--- a/__tests__/pension-calculations.test.ts
+++ b/__tests__/pension-calculations.test.ts
@@ -5,6 +5,7 @@ import {
   calculateRetirementEligibility,
   calculateCOLAProjection,
   calculateMultiGroupPension,
+  generateMultiGroupProjectionTable,
   type PensionCalculationResult,
   type EmployeeGroup
 } from '@/lib/pension-calculations'
@@ -400,6 +401,69 @@ describe('Pension Calculations', () => {
       expect(result.baseAnnualPension).toBeCloseTo(52000, 2)
       expect(result.annualPension).toBeCloseTo(52000 * 0.9065, 0)
       expect(result.survivorAnnualPension).toBeCloseTo(result.annualPension * (2 / 3), 0)
+    })
+  })
+
+  describe('generateMultiGroupProjectionTable', () => {
+    it('rows reflect blended base% (not retirement-group single-group approximation)', () => {
+      // 5 yrs Group 4 + 26 yrs Group 2, age 55. Retiring row:
+      //   - Single-group would show 2.0% * 31 = 62.0% (wrong for multi-group).
+      //   - Multi-group should show 2.5%*5 + 2.0%*26 = 0.125 + 0.520 = 0.645 = 64.5%.
+      const rows = generateMultiGroupProjectionTable(
+        [
+          { group: 'GROUP_4', yearsOfService: 5 },
+          { group: 'GROUP_2', yearsOfService: 26 },
+        ],
+        55,
+        80000,
+        'A',
+        '',
+        'before_2012',
+      ).rows
+
+      expect(rows.length).toBeGreaterThan(0)
+      const retirementRow = rows[0]
+      expect(retirementRow.age).toBe(55)
+      expect(retirementRow.yearsOfService).toBe(31)
+      // Critical: must be 64.5%, not 62.0% single-group value.
+      expect(retirementRow.totalBenefitPercentage).toBeCloseTo(0.645, 4)
+      expect(retirementRow.annualPension).toBeCloseTo(80000 * 0.645, 2)
+    })
+
+    it('caps at 80% once combined percentage exceeds the limit', () => {
+      const { rows } = generateMultiGroupProjectionTable(
+        [
+          { group: 'GROUP_4', yearsOfService: 5 },
+          { group: 'GROUP_2', yearsOfService: 30 },
+        ],
+        55,
+        80000,
+        'A',
+        '',
+        'before_2012',
+      )
+      const lastRow = rows[rows.length - 1]
+      expect(lastRow.totalBenefitPercentage).toBeLessThanOrEqual(0.8 + 1e-9)
+      // With a starting base of 72.5%, the projection should reach the 80% cap.
+      const cappedRow = rows.find(r => r.totalBenefitPercentage >= 0.8 - 1e-9)
+      expect(cappedRow).toBeDefined()
+    })
+
+    it('title labels both segment groups for clarity', () => {
+      const { title } = generateMultiGroupProjectionTable(
+        [
+          { group: 'GROUP_4', yearsOfService: 5 },
+          { group: 'GROUP_2', yearsOfService: 26 },
+        ],
+        55,
+        80000,
+        'A',
+        '',
+        'before_2012',
+      )
+      expect(title).toContain('GROUP 4')
+      expect(title).toContain('GROUP 2')
+      expect(title).toContain('Multi-Group')
     })
   })
 })

--- a/components/pension-calculator.tsx
+++ b/components/pension-calculator.tsx
@@ -21,6 +21,7 @@ import {
   checkEligibility,
   getBenefitFactor,
   generateProjectionTable,
+  generateMultiGroupProjectionTable,
   calculateMultiGroupPension,
 } from "@/lib/pension-calculations"
 import { FREE_TIER_LIMITS } from "@/lib/stripe/config"
@@ -780,11 +781,15 @@ export default function PensionCalculator() {
           localStorage.setItem(USAGE_KEY, String(prevCount + 1))
         }
 
-        // Projection table uses the retirement group (last segment) with total YOS.
-        const projectionData = generateProjectionTable(
-          group,
+        // Multi-group projection: hold earlier segment(s) constant and grow
+        // only the retirement-segment YOS year over year via calculateMultiGroupPension,
+        // so blended base% and 80% cap reflect the real career mix.
+        const projectionData = generateMultiGroupProjectionTable(
+          [
+            { group: formData.secondaryGroup, yearsOfService: secondaryYears },
+            { group, yearsOfService: primaryYears },
+          ],
           enteredAge,
-          enteredYOS,
           averageSalary,
           formData.retirementOption,
           formData.beneficiaryAge,

--- a/lib/pension-calculations.ts
+++ b/lib/pension-calculations.ts
@@ -690,6 +690,100 @@ export function calculateMultiGroupPension(
   }
 }
 
+/**
+ * Projection table for multi-group careers. Holds earlier segments constant
+ * and grows only the retirement (final) segment year-over-year, routing each
+ * row through calculateMultiGroupPension so the blended base% and 80% cap
+ * reflect the actual career mix — not a single-group approximation.
+ *
+ * The "factor" column shows the retirement-group's benefit factor at the
+ * projected age (the factor that applies to the incremental year of service),
+ * matching the single-group table's semantics.
+ */
+export function generateMultiGroupProjectionTable(
+  segments: CareerSegment[],
+  projectionStartAge: number,
+  averageSalary: number,
+  selectedOption: string,
+  beneficiaryAgeStr: string,
+  serviceEntry: string,
+) {
+  if (segments.length === 0) {
+    return { rows: [], title: "Pension Projection" }
+  }
+
+  const retirementGroup = segments[segments.length - 1].group
+  const retirementGroupIdx = segments.length - 1
+  const groupMaxAgeLimits: Record<string, number> = {
+    GROUP_1: 70,
+    GROUP_2: 68,
+    GROUP_3: 68,
+    GROUP_4: 65,
+  }
+  const maxAge = groupMaxAgeLimits[retirementGroup] ?? 70
+  const maxIterations = 30
+
+  const rows: Array<{
+    age: number
+    yearsOfService: number
+    factor: number
+    totalBenefitPercentage: number
+    annualPension: number
+    monthlyPension: number
+    survivorAnnual: number | string
+    survivorMonthly: number | string
+  }> = []
+
+  for (let yearOffset = 0; yearOffset < maxIterations; yearOffset++) {
+    const currentAge = projectionStartAge + yearOffset
+    if (Math.floor(currentAge) > maxAge) break
+
+    const projSegments = segments.map((seg, idx) =>
+      idx === retirementGroupIdx
+        ? { ...seg, yearsOfService: seg.yearsOfService + yearOffset }
+        : seg,
+    )
+
+    const result = calculateMultiGroupPension(
+      projSegments,
+      currentAge,
+      averageSalary,
+      selectedOption as "A" | "B" | "C",
+      serviceEntry,
+      beneficiaryAgeStr,
+    )
+
+    if (!result.eligible) continue
+
+    const currentTotalYOS = projSegments.reduce((s, seg) => s + seg.yearsOfService, 0)
+    const retirementGroupFactor = getBenefitFactor(
+      Math.floor(currentAge),
+      retirementGroup,
+      serviceEntry,
+      currentTotalYOS,
+    )
+
+    rows.push({
+      age: currentAge,
+      yearsOfService: currentTotalYOS,
+      factor: retirementGroupFactor,
+      totalBenefitPercentage: result.basePercentage,
+      annualPension: result.annualPension,
+      monthlyPension: result.monthlyPension,
+      survivorAnnual: selectedOption === "C" ? result.survivorAnnualPension : "N/A",
+      survivorMonthly: selectedOption === "C" ? result.survivorMonthlyPension : "N/A",
+    })
+
+    if (result.basePercentage >= MAX_PENSION_PERCENTAGE_OF_SALARY) break
+  }
+
+  const groupLabels = segments.map(s => s.group.replace("_", " ")).join(" + ")
+  return {
+    rows,
+    title: `Multi-Group Pension Projection (${groupLabels}, From Age ${projectionStartAge} up to 80% Max)`,
+  }
+}
+
 	// ---------------------------------------------------------------------------
 	// Legacy-compatible types & helper functions
 	// ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug
For a 5×Group 4 + 26×Group 2 career at age 55, the projection table showed `2.0% × 31 = 62.0%` instead of the correct multi-group blend `2.5%×5 + 2.0%×26 = 64.5%`. The table title also read "GROUP 2 Pension Projection" which contradicted the headline multi-group result above it. Reported on production at masspension.com/calculator.

## Fix
- `lib/pension-calculations.ts` — new `generateMultiGroupProjectionTable()` holds earlier segment(s) constant and grows only the retirement segment year over year, routing each row through `calculateMultiGroupPension` so blended base%, option reductions, and the 80% cap match the headline result. Title labels both segment groups.
- `components/pension-calculator.tsx` — multi-group branch swaps to the new projection function.
- `__tests__/pension-calculations.test.ts` — 3 new tests including the canonical 5×Group4 + 26×Group2 = 64.5% scenario that catches the bug.

## Verification
- [x] `npm run build` clean
- [x] All 37 pension tests pass

https://claude.ai/code/session_01NQsNPGoFoSYzkj7SCmL6BN

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQsNPGoFoSYzkj7SCmL6BN)_